### PR TITLE
GetAbsoluteAngle improves

### DIFF
--- a/mathutil.inc
+++ b/mathutil.inc
@@ -13,9 +13,8 @@
 
 // Truncates a value to the range 0.0 - 360.0
 stock Float:GetAbsoluteAngle(Float:angle) {
-	new const Float:temp = floatround(angle / 360, floatround_floor) * 360;
-	// check if temp mod angle is 0 then we distract by 360
-	return angle - (temp >= 360 && angle == temp ? temp - 360 : temp);
+	// Note that 360 is equal to 0
+	return ((angle / 360.0) - floatround((angle / 360.0), floatround_floor)) * 360.0;
 }
 
 // Returns the offset heading from north between a point and a destination

--- a/mathutil.inc
+++ b/mathutil.inc
@@ -13,13 +13,9 @@
 
 // Truncates a value to the range 0.0 - 360.0
 stock Float:GetAbsoluteAngle(Float:angle) {
-	while(angle < 0.0) {
-		angle += 360.0;
-	}
-	while(angle > 360.0) {
-		angle -= 360.0;
-	}
-	return angle;
+	new const Float:temp = floatround(angle / 360, floatround_floor) * 360;
+	// check if temp mod angle is 0 then we distract by 360
+	return angle - (temp >= 360 && angle == temp ? temp - 360 : temp);
 }
 
 // Returns the offset heading from north between a point and a destination


### PR DESCRIPTION
I change `GetAbsoluteAngle` formula, that will be faster than using looping.
Because i use modulo, if `angle` is divisor of `360` function will returned `0` instead `360` which is literally the same.